### PR TITLE
Maximum Items dropped on Death Reduced

### DIFF
--- a/Classic Dereth.vcxproj
+++ b/Classic Dereth.vcxproj
@@ -328,6 +328,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>./Source;./Source/PhatSDK;./Source/PhatSDK/Support;./Lib;./Resource</AdditionalIncludeDirectories>
       <AdditionalOptions>/Zm200 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ws2_32.lib;comctl32.lib;Lib\zlib\zlibstatDebug.lib;Lib\mysql\libmysql.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -472,7 +472,8 @@ void CPlayerWeenie::CalculateAndDropDeathItems(CCorpseWeenie *pCorpse)
 		return;
 
 	int level = InqIntQuality(LEVEL_INT, 1);
-	int amountOfItemsToDrop = max(floor((float)level / 10.0), 1);
+	int maxItemsToDrop = 12; // Limit the amount of items that can be dropped + random adjustment
+	int amountOfItemsToDrop = std::clamp(level / 10, 1, maxItemsToDrop); // std::clamp requires C++17 standards
 	if (level > 10)
 		amountOfItemsToDrop += Random::GenUInt(0, 2);
 


### PR DESCRIPTION
Player feedback from Hightide indicated that the number of items dropped on death was far too high. The old formula used to calculate death item drop only anticipated a maximum level of 126 at that time. With a maximum character level of 275 you could end up dropping 29 items per death. We felt this was too extreme and opted to put in a hard cap of 14 items dropped (120/10 + (rand 0-2)) and capping it at level 120. 

The old code was inexplicably changing the integers to a float and back again. This seems very unnecessary and the new implementation keeps everything as integers and uses the clamp function from std:c++17. No standard was defined the project properties so I went ahead and set it to c++17. If for some reason we need to use the older standards, then the clamp function could be replaced with min(max()) instead. 

I haven't had time to setup a database and test server yet so please check this patch before pushing out to live. Thank you